### PR TITLE
Disable ECS public IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ The Terraform files in `infra/` create the following resources:
 - Auto scaling policy based on CPU utilization
 
 Before running Terraform, provide IDs for your existing VPC and subnets by setting the following variables. You can copy `infra/terraform.tfvars.example` to `infra/terraform.tfvars` and edit the values:
-=======
-Before running Terraform, provide IDs for your existing VPC and subnets by setting the following variables:
 
 - `vpc_id`
 - `public_subnets` (for the load balancer)
@@ -43,6 +41,8 @@ The workflow in `.github/workflows/deploy.yml` automatically builds the Docker i
 - `VPC_ID` – ID of your VPC
 - `PUBLIC_SUBNETS` – JSON list of public subnet IDs
 - `PRIVATE_SUBNETS` – JSON list of private subnet IDs
+
+The ECS tasks are launched in the specified private subnets without a public IP address.
 
 ## Environment Variables
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -122,11 +122,12 @@ resource "aws_ecs_service" "app" {
   task_definition = aws_ecs_task_definition.app.arn
   desired_count   = var.desired_count
   launch_type     = "FARGATE"
+  health_check_grace_period_seconds = 0
 
   network_configuration {
     subnets         = var.private_subnets
     security_groups = [aws_security_group.task.id]
-    assign_public_ip = true
+    assign_public_ip = false
   }
 
   load_balancer {


### PR DESCRIPTION
## Summary
- do not assign public IPs for ECS tasks
- document that tasks run in private subnets
- fix README formatting issue

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6866579ea4e88321acbc080f477caaa5