### PR TITLE
Make private_subnets optional

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           terraform -chdir=infra apply -auto-approve \
             -var="vpc_id=$VPC_ID" \
             -var="public_subnets=$PUBLIC_SUBNETS" \
-            -var="private_subnets=$PRIVATE_SUBNETS"
+            ${PRIVATE_SUBNETS:+-var="private_subnets=$PRIVATE_SUBNETS"}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Before running Terraform, provide IDs for your existing VPC and subnets by setti
 
 - `vpc_id`
 - `public_subnets` (for the load balancer)
-- `private_subnets` (for the ECS service)
+- `private_subnets` (for the ECS service, optional)
 
 Example initialization:
 
@@ -24,8 +24,9 @@ Example initialization:
 terraform -chdir=infra init
 terraform -chdir=infra apply -auto-approve \
   -var="vpc_id=vpc-xxxx" \
-  -var="public_subnets=[\"subnet-a\",\"subnet-b\"]" \
-  -var="private_subnets=[\"subnet-c\",\"subnet-d\"]"
+  -var="public_subnets=[\"subnet-a\",\"subnet-b\"]"
+# Optionally specify private subnets
+# -var="private_subnets=[\"subnet-c\",\"subnet-d\"]"
 ```
 
 The output `alb_dns_name` provides the public endpoint of the service.
@@ -40,9 +41,9 @@ The workflow in `.github/workflows/deploy.yml` automatically builds the Docker i
 - `ECS_CLUSTER` and `ECS_SERVICE` (created by Terraform)
 - `VPC_ID` – ID of your VPC
 - `PUBLIC_SUBNETS` – JSON list of public subnet IDs
-- `PRIVATE_SUBNETS` – JSON list of private subnet IDs
+- `PRIVATE_SUBNETS` – JSON list of private subnet IDs (optional)
 
-The ECS tasks are launched in the specified private subnets without a public IP address.
+If private subnets are provided, the ECS tasks are launched in them without a public IP address. Otherwise the tasks run in the public subnets.
 
 ## Environment Variables
 
@@ -50,12 +51,12 @@ For local development copy `.env.example` to `.env` and adjust values as needed.
 
 ## Troubleshooting
 
-If `terraform apply` fails with errors like `Missing expression` or `No value for required variable`, ensure you supply values for `vpc_id`, `public_subnets`, and `private_subnets`. Example with placeholder IDs:
+If `terraform apply` fails with errors like `Missing expression` or `No value for required variable`, ensure you supply values for `vpc_id` and `public_subnets`. The `private_subnets` variable is optional. Example with placeholder IDs:
 
 ```bash
 terraform -chdir=infra apply -auto-approve \
   -var="vpc_id=vpc-12345678" \
-  -var="public_subnets=[\"subnet-aaaabbbb\"]" \
-  -var="private_subnets=[\"subnet-ccccdddd\"]"
+  -var="public_subnets=[\"subnet-aaaabbbb\"]"
+  # -var="private_subnets=[\"subnet-ccccdddd\"]"
 ```
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -125,7 +125,7 @@ resource "aws_ecs_service" "app" {
   health_check_grace_period_seconds = 0
 
   network_configuration {
-    subnets         = var.private_subnets
+    subnets         = length(var.private_subnets) > 0 ? var.private_subnets : var.public_subnets
     security_groups = [aws_security_group.task.id]
     assign_public_ip = false
   }

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,3 +1,3 @@
 vpc_id = "vpc-xxxxxxxx"
 public_subnets = ["subnet-aaaa", "subnet-bbbb"]
-private_subnets = ["subnet-cccc", "subnet-dddd"]
+# private_subnets = ["subnet-cccc", "subnet-dddd"]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -41,4 +41,5 @@ variable "public_subnets" {
 variable "private_subnets" {
   description = "Private subnets for ECS"
   type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
## Summary
- make `private_subnets` optional by setting an empty list default
- fall back to the public subnets when none are provided
- document the optional variable in README and example tfvars
- allow optional `private_subnets` in the GitHub Actions workflow

## Testing
- `terraform -chdir=infra init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_b_686662150fd88325a4e6f2350e4cf376