### PR TITLE
Fix Terraform task definition parsing

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -11,6 +11,10 @@ provider "aws" {
   region = var.aws_region
 }
 
+locals {
+  task_definition = jsondecode(file("${path.module}/task-definition.json"))
+}
+
 resource "aws_ecr_repository" "app" {
   name = var.ecr_repo_name
 }
@@ -113,7 +117,7 @@ resource "aws_ecs_task_definition" "app" {
   cpu                      = "256"
   memory                   = "512"
 
-  container_definitions = file("${path.module}/task-definition.json")
+  container_definitions = jsonencode(local.task_definition.containerDefinitions)
 }
 
 resource "aws_ecs_service" "app" {


### PR DESCRIPTION
## Summary
- parse the task definition JSON file in Terraform
- pass only the container definitions to `aws_ecs_task_definition`

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_b_686665b23d348325912dced209463205