### PR TITLE
Handle optional private subnets and parse ECS task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,14 @@ terraform -chdir=infra apply -auto-approve \
   # -var="private_subnets=[\"subnet-ccccdddd\"]"
 ```
 
+
+## Importing existing AWS resources
+
+If resources like the ECR repository or IAM roles were created outside of Terraform, you can bring them under management without deleting them. Use `terraform import` before running `terraform apply`:
+
+```bash
+terraform -chdir=infra import aws_ecr_repository.app myonsite-api
+terraform -chdir=infra import aws_iam_role.task_execution myonsite-service-exec
+```
+
+After the import completes, run `terraform plan` to review any changes and then `terraform apply`.


### PR DESCRIPTION
## Summary
- show how to provide optional `private_subnets` in README
- document importing existing AWS resources with `terraform import`
- parse the task definition JSON with a `locals` block
- only pass container definitions in the task definition resource
- adjust subnet logic so ECS tasks fall back to public subnets
- keep example `terraform.tfvars` optional and format Terraform

## Testing
- `terraform -chdir=infra fmt -check`
- `terraform -chdir=infra init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform -chdir=infra validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_b_686665b23d348325912dced209463205