### PR TITLE
Configure S3 backend for Terraform state

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ terraform -chdir=infra apply -auto-approve \
 
 The output `alb_dns_name` provides the public endpoint of the service.
 
+### Terraform State Backend
+
+Terraform state is stored remotely in an S3 bucket so it can be shared across
+developers and CI runs. Ensure your AWS credentials are configured and run
+`terraform init` to connect to the backend. Avoid manually deleting state files.
+
+To create the backend if it does not already exist:
+
+```bash
+aws s3api create-bucket --bucket myonsite-terraform-state --region us-east-1
+aws dynamodb create-table \
+  --table-name terraform-locks \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST
+```
+
 ## GitHub Actions Deployment
 
 The workflow in `.github/workflows/deploy.yml` automatically builds the Docker image, pushes it to ECR and updates the ECS service when changes are pushed to the `main` branch. Configure the following secrets in your GitHub repository:

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "myonsite-terraform-state"
+    key            = "myonsite-api/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
## Summary
- store Terraform state in S3 so CI runs share state
- document remote backend setup instructions

## Testing
- `terraform fmt -check infra/*.tf`
- `npm test` *(fails: Error: no test specified)*
- `terraform -chdir=infra init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_b_6866835cd81083258a5a74e244485f2d