### PR TITLE
Fix test failures on Alpine 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # Use Node.js LTS version with Alpine
-FROM node:18-alpine
+FROM node:18-alpine3.20
 
 # Install Python and build dependencies
-RUN apk add --no-cache python3 make g++
+RUN apk add --no-cache python3 py3-setuptools make g++ \
+    && ln -sf python3 /usr/bin/python
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Summary
- update Dockerfile to use Alpine 3.20
- install py3-setuptools for Python `distutils` and add `python` symlink

## Testing
- `npm install --ignore-scripts`

------
https://chatgpt.com/codex/tasks/task_b_686686ebd5dc832186e0c46a2d4d5e1b