### PR TITLE
Add terraform.tfvars with default VPC settings

### DIFF
--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,0 +1,4 @@
+vpc_id = "vpc-0e08d0c15d7405acc"
+public_subnets = ["subnet-057a58c51661c2b64", "subnet-0b864d1dc086bd053"]
+# These appear to be your private subnets based on the ECS service config
+# private_subnets = ["subnet-057a58c51661c2b64", "subnet-0b864d1dc086bd053"]


### PR DESCRIPTION
## Summary
- add `terraform.tfvars` with example VPC and subnet IDs

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686693ecab1883218cfafe5bae268d26